### PR TITLE
Fix: Resolve mPointCloudMesh Initialization Timing Issue

### DIFF
--- a/src/ofxOrbbecCamera.cpp
+++ b/src/ofxOrbbecCamera.cpp
@@ -195,6 +195,9 @@ bool ofxOrbbecCamera::open(ofxOrbbec::Settings aSettings){
                 }else{
                     config->setAlignMode(ALIGN_DISABLE);
                 }
+
+                mPointCloudMesh = ofMesh();
+                mPointCloudMesh.setMode(OF_PRIMITIVE_POINTS);
             }
             
 
@@ -550,12 +553,8 @@ void ofxOrbbecCamera::pointCloudToMesh(shared_ptr<ob::Frame> frame, bool bRGB){
             pointsSize = frame->dataSize() / sizeof(OBPoint);
         }
 
-        mPointCloudMesh = ofMesh();  
         mPointCloudPts.clear();
         mPointCloudPts.reserve(pointsSize);
-
-        mPointCloudMesh.setMode(OF_PRIMITIVE_POINTS);
-
 
         if( bRGB ){
             std::vector <ofFloatColor> tColors;
@@ -570,6 +569,7 @@ void ofxOrbbecCamera::pointCloudToMesh(shared_ptr<ob::Frame> frame, bool bRGB){
 
                 point++;
             }
+            mPointCloudMesh.clear();
             mPointCloudMesh.addColors(tColors);
 
         }else{
@@ -580,6 +580,7 @@ void ofxOrbbecCamera::pointCloudToMesh(shared_ptr<ob::Frame> frame, bool bRGB){
                 mPointCloudPts.push_back(pt);
                 point++;
             }
+            mPointCloudMesh.clear();
         }
 
         mPointCloudMesh.addVertices(mPointCloudPts);


### PR DESCRIPTION
**Issue:**
Addresses a bug where the mPointCloudMesh member variable was frequently empty during drawing due to premature re-initialization in a separate thread. This resulted in the main thread fetching data after re-initialization but before new vertices were added to the mesh.

**Solution:**
To resolve this issue, the fix involves clearing the PointCloudMesh just bedore adding the new vertices data to it, ensuring a more reliable and consistent rendering experience.

**Changes Made:**
Moved initialization of the mPointCloudMesh member variable in the ofxOrbbecCamera::open function and we now clear the member variable just before adding the new color and vertices data.



