### PR TITLE
Depth Rotation Support

### DIFF
--- a/src/ofxOrbbecCamera.cpp
+++ b/src/ofxOrbbecCamera.cpp
@@ -222,6 +222,10 @@ bool ofxOrbbecCamera::open(ofxOrbbec::Settings aSettings){
 
             // Pass in the configuration and start the pipeline
             mPipe->start(config);
+            
+            if (device->isPropertySupported(OB_PROP_DEPTH_ROTATE_INT, OB_PERMISSION_WRITE)) {
+                device->setIntProperty(OB_PROP_DEPTH_ROTATE_INT, aSettings.rotation);
+            }
 
             if( aSettings.bPointCloud || aSettings.bPointCloudRGB ){
                 auto cameraParam = mPipe->getCameraParam();

--- a/src/ofxOrbbecCamera.h
+++ b/src/ofxOrbbecCamera.h
@@ -34,6 +34,8 @@ struct Settings{
     int deviceID = 0;
     std::string deviceSerial = "";
 
+    OBRotateDegreeType rotation = OB_ROTATE_DEGREE_0;
+
     FrameType depthFrameSize;
     FrameType colorFrameSize; 
     


### PR DESCRIPTION
Hello!

Than you for the addon! We are using it in our digital art project and we needed to implement the depth camera rotation feature, available in Orbbec API.

There are four rotation parameters:

```
OB_ROTATE_DEGREE_0 = 0, ///< Rotate 0
OB_ROTATE_DEGREE_90 = 90, ///< Rotate 90
OB_ROTATE_DEGREE_180 = 180, ///< Rotate 180
OB_ROTATE_DEGREE_270 = 270, ///< Rotate 270
```
Now they can be set in an ofx project with `settings.rotation = OB_ROTATE_DEGREE_90;`
The default rotation is set to 0. 